### PR TITLE
remove unsightly left/right inline padding of code within pre blocks

### DIFF
--- a/markdown.css
+++ b/markdown.css
@@ -32,6 +32,10 @@ code{
     -moz-border-radius: 2px;
     border-radius: 2px; 
 }
+pre code {
+    padding-left: 0px;
+    padding-right: 0px;
+}
 li p{
     margin: 0.3em;
 }


### PR DESCRIPTION
Like it says.

The left/right padding for `code` looks bad when it's contained within a `pre` block, which happens when you do this in markdown:

```
Here is some text.

    do_something();
    do_something_else();

Here is some more text.
```

In this case `do_something();` would have 3px of padding to the left of it, where `do_something_else();` would not. This patch fixes that.
